### PR TITLE
eldoc: add try/catch

### DIFF
--- a/src/babashka/nrepl/impl/server.clj
+++ b/src/babashka/nrepl/impl/server.clj
@@ -125,13 +125,14 @@
     (utils/send os (utils/response-for msg {"sessions" sessions
                                             "status" #{"done"}}) opts)))
 
-(defn eldoc [ctx msg os opts]
+(defn eldoc [ctx msg os  {:keys [debug] :as opts}]
   (let [ns-str (:ns msg)
         sym-str (:sym msg)
         sci-ns (when ns-str
                  (sci-utils/namespace-object (:env ctx) (symbol ns-str) nil false))]
-    (sci/binding [vars/current-ns (or sci-ns @vars/current-ns)]
-      (let [m (eval-string* ctx (format "
+    (try
+      (sci/binding [vars/current-ns (or sci-ns @vars/current-ns)]
+        (let [m (eval-string* ctx (format "
 (when-let [v (ns-resolve '%s '%s)]
   (let [m (meta v)]
     (assoc m :arglists (:arglists m)
@@ -139,16 +140,19 @@
      :name (:name m)
      :ns (some-> m :ns ns-name)
      :val @v)))" ns-str sym-str))
-            reply {"ns" (:ns m)
-                   "name" (:name m)
-                   "eldoc" (mapv #(mapv str %) (:arglists m))
-                   "type" (cond
-                            (ifn? (:val m)) "function"
-                            :else "variable")
-                   "docstring" (:doc m)
-                   "status" #{"done"}}]
-        (utils/send os
-                    (utils/response-for msg reply) opts)))))
+              reply {"ns" (:ns m)
+                     "name" (:name m)
+                     "eldoc" (mapv #(mapv str %) (:arglists m))
+                     "type" (cond
+                              (ifn? (:val m)) "function"
+                              :else "variable")
+                     "docstring" (:doc m)
+                     "status" #{"done"}}]
+          (utils/send os
+                      (utils/response-for msg reply) opts)))
+      (catch Throwable e
+        (when debug (println e))
+        (utils/send os (utils/response-for msg {"status" #{"done" "no-eldoc"}}) opts)))))
 
 (defn read-msg [msg]
   (-> (zipmap (map keyword (keys msg))

--- a/test/babashka/nrepl/server_test.clj
+++ b/test/babashka/nrepl/server_test.clj
@@ -267,7 +267,13 @@
                                      "session" session "id" (new-id!)})
           (let [{:keys [docstring type]} (read-reply in session @id)]
             (is (str/includes? docstring "foo"))
-            (is (= "variable" type))))))))
+            (is (= "variable" type))))
+        (testing "eldoc of invalid characters"
+          (bencode/write-bencode os {"op" "eldoc" "ns" "user"
+                                     "sym" ""
+                                     "session" session "id" (new-id!)})
+          (let [{:keys [status]} (read-reply in session @id)]
+            (is (contains? (set status) "no-eldoc"))))))))
 
 (deftest nrepl-server-test
   (let [service (atom nil)]


### PR DESCRIPTION
Thanks for the feature add! I was slowly understanding how nrepl and sci works, but life happened and I wasn't moving fast.

I've tried it and it works fairly well, however sometimes it hangs. Apparently CIDER can send weird things to eldoc, like a carriage return:

```
(-->
  id         "19"
  op         "eldoc"
  session    "f9d56796-ad01-4ab0-bf5d-17c2458fa772"
  time-stamp "2020-06-17 19:57:18.666302371"
  ns         "user"
  sym        "
"
)
```

Which throws an error when passing it to `(ns-resolve '%s '%s) ` and hangs the nrepl server. I added a try/catch for that.