### PR TITLE
add print writer for stderr

### DIFF
--- a/src/babashka/nrepl/impl/server.clj
+++ b/src/babashka/nrepl/impl/server.clj
@@ -25,12 +25,15 @@
       (sci/with-bindings (cond-> {}
                            sci-ns (assoc vars/current-ns sci-ns))
         (loop []
-          (let [pw (utils/replying-print-writer o msg opts)
+          (let [out-pw (utils/replying-print-writer "out" o msg opts)
+                err-pw (utils/replying-print-writer "err" o msg opts)
                 form (p/parse-next ctx reader)
                 value (if (identical? :edamame.impl.parser/eof form) ::nil
-                          (let [result (sci/with-bindings {sci/out pw}
+                          (let [result (sci/with-bindings {sci/out out-pw
+                                                           sci/err err-pw}
                                          (eval-form ctx form))]
-                            (.flush pw)
+                            (.flush out-pw)
+                            (.flush err-pw)
                             result))
                 env (:env ctx)]
             (swap! env update-in [:namespaces 'clojure.core]

--- a/src/babashka/nrepl/impl/utils.clj
+++ b/src/babashka/nrepl/impl/utils.clj
@@ -43,7 +43,7 @@
   of the content written to that `PrintWriter` will be sent as messages on the
   transport of `msg`, keyed by `key`."
   ^java.io.PrintWriter
-  [o msg opts]
+  [key o msg opts]
   (-> (proxy [Writer] []
         (write
           ([x]
@@ -54,7 +54,7 @@
                  text (str (doto (StringWriter.)
                              (.write cbuf ^int off ^int len)))]
              (when (pos? (count text))
-               (send o (response-for msg {"out" text}) opts)))))
+               (send o (response-for msg {key text}) opts)))))
         (flush [])
         (close []))
       (BufferedWriter. 1024)


### PR DESCRIPTION
Add a `key` argument to `replying-print-writer` so error can be sent to stderr (https://github.com/babashka/babashka.nrepl/issues/28)
I copied the tests for output and reused them for error.