### PR TITLE
Print out the actual port used by the nREPL server

### DIFF
--- a/src/babashka/nrepl/server.clj
+++ b/src/babashka/nrepl/server.clj
@@ -27,7 +27,7 @@
         inet-address (java.net.InetAddress/getByName host)
         socket-server (new ServerSocket port 0 inet-address)]
     (when-not quiet
-      (println (format "Started nREPL server at %s:%d" (.getHostAddress inet-address) port)))
+      (println (format "Started nREPL server at %s:%d" (.getHostAddress inet-address) (.getLocalPort socket-server))))
     {:socket socket-server
      :future (sci/future
                (server/listen ctx socket-server opts))}))


### PR DESCRIPTION
This way you can pass in 0 and have the operating system assign a port.

```
➜ bb --nrepl-server 0 
Started nREPL server at 127.0.0.1:33427
For more info visit https://github.com/borkdude/babashka/blob/master/doc/repl.md#nrepl.
```