### PR TITLE
add nrepl info and lookup operation support

### DIFF
--- a/src/babashka/nrepl/impl/utils.clj
+++ b/src/babashka/nrepl/impl/utils.clj
@@ -2,7 +2,8 @@
   {:author "Michiel Borkent"
    :no-doc true}
   (:refer-clojure :exclude [send])
-  (:require [bencode.core :refer [write-bencode]])
+  (:require [bencode.core :refer [write-bencode]]
+            [clojure.string :as str])
   (:import [java.io Writer PrintWriter StringWriter OutputStream BufferedWriter]))
 
 (set! *warn-on-reflection* true)


### PR DESCRIPTION
Adds handling of :lookup and :info operations, so that IDEs can offer
function parameters and documentation strings of functions.