### PR TITLE
Always prefix error loc-str with a space

### DIFF
--- a/src/babashka/nrepl/impl/utils.clj
+++ b/src/babashka/nrepl/impl/utils.clj
@@ -35,8 +35,7 @@
     (when debug (prn "sending exception" ex-map))
     (send os (response-for msg {"err" (str ex-name
                                            (when cause (str ": " cause))
-                                           (when (and cause loc-str) " ")
-                                           loc-str "\n")}) opts)
+                                           " " loc-str "\n")}) opts)
     (send os (response-for msg {"ex" (str "class " ex-name)
                                 "root-ex" (str "class " ex-name)
                                 "status" #{"eval-error"}}) opts)

--- a/test/babashka/nrepl/server_test.clj
+++ b/test/babashka/nrepl/server_test.clj
@@ -371,7 +371,7 @@
         (testing "exception value"
           (bencode/write-bencode os {"op" "eval" "code" "(nth [] 3)"
                                      "session" session "id" (new-id!)})
-          (is (= "java.lang.IndexOutOfBoundsExceptioncore REPL:1:1\n" (:err (read-reply in session @id)))))))))
+          (is (= "java.lang.IndexOutOfBoundsException core REPL:1:1\n" (:err (read-reply in session @id)))))))))
 
 (deftest nrepl-server-test
   (let [service (atom nil)]


### PR DESCRIPTION
With or without a cause, we need a space between the previous part of
the message and the loc-str. Without this you'll end up with the ex-name
right up against the loc-str. This way we separate the loc-str from the
ex-name if there's no cause while still having a space if there is a
cause.