### PR TITLE
Add user-middlware

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ value:
     babashka.nrepl.server/start-server!)
 ```
 
+## user-middleware
+
+`start-server!` accepts an opts arg `:user-middlware`.
+This should be a seq of fully qualified symbols that are resolvable by sci.
+Each symbol should be a function in the style of a middleware wrapper.
+Also see [TODO: link babashka example readme]
+
+
 ## Authors
 
 The main body of work was done by Michiel Borkent

--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ value:
     babashka.nrepl.server/start-server!)
 ```
 
-## user-middleware
+## User-middleware
+
+Middlware functions defined in babashka user sources.
 
 `start-server!` accepts an opts arg `:user-middlware`.
 This should be a seq of fully qualified symbols that are resolvable by sci.
 Each symbol should be a function in the style of a middleware wrapper.
 Also see [TODO: link babashka example readme]
-
 
 ## Authors
 

--- a/src/babashka/nrepl/server.clj
+++ b/src/babashka/nrepl/server.clj
@@ -20,14 +20,27 @@
     {:host host
      :port port}))
 
-(defn start-server! [ctx & [{:keys [host port quiet]
+(defn ->sci-var [sci-ctx sym]
+  (or (sci/eval-form sci-ctx `(requiring-resolve '~sym))
+      (throw (Exception. (str "Failed to resolve " sym)))))
+
+(defn ->user-middleware [sci-ctx middlware]
+  (sequence
+   (comp
+    (map #(->sci-var sci-ctx %))
+    (map middleware/middleware->transducer))
+   middlware))
+
+(defn start-server! [ctx & [{:keys [host port quiet user-middleware]
                              :or {host "0.0.0.0"
                                   port 1667}
                              :as opts}]]
   (let [ctx (assoc ctx :sessions (atom #{}))
         opts (assoc opts :xform
                     (get opts :xform
-                         middleware/default-xform))
+                         (middleware/middleware->xform
+                          (into middleware/default-middleware
+                                (->user-middleware ctx user-middleware)))))
         inet-address (java.net.InetAddress/getByName host)
         socket-server (new ServerSocket port 0 inet-address)]
     (when-not quiet

--- a/src/babashka/nrepl/server/middleware.clj
+++ b/src/babashka/nrepl/server/middleware.clj
@@ -144,3 +144,12 @@
          (disj #'wrap-process-message)
          (conj op-handler)))))
 
+(defn middleware->transducer
+  "Return a transducer from a `middleware`."
+  ([middleware]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result input]
+        ((middleware #(rf result %)) input))))))

--- a/src/babashka/nrepl/server/middleware.clj
+++ b/src/babashka/nrepl/server/middleware.clj
@@ -147,7 +147,7 @@
 (defn
   middleware->transducer
   "Return a transducer from a `middleware`.
-  Preserves `::requires` and `::expects` metadata of `middlware`.
+  Preserves `::requires` and `::expects` metadata of `middleware`.
   See https://github.com/babashka/babashka.nrepl/blob/master/doc/middleware.md."
   ([middleware]
   (let [f

--- a/test/babashka/nrepl/server_test.clj
+++ b/test/babashka/nrepl/server_test.clj
@@ -631,8 +631,8 @@
               _ (sci/eval-string*
                  ctx
                  "(defn
-^{:babashka.nrepl.server.middleware/requires #{'middleware/wrap-read-msg}
-  :babashka.nrepl.server.middleware/expects #{'middleware/wrap-process-message}}
+^{:babashka.nrepl.server.middleware/requires #{'babashka.nrepl.server.middleware/wrap-read-msg}
+  :babashka.nrepl.server.middleware/expects #{'babashka.nrepl.server.middleware/wrap-process-message}}
  log-requests-middleware [handler]
   (fn [request]
     (swap! requests-log conj (:msg request))
@@ -667,15 +667,15 @@
               _ (sci/eval-string*
                  ctx
                  "(defn
-^{:babashka.nrepl.server.middleware/requires #{'middleware/wrap-read-msg}
-  :babashka.nrepl.server.middleware/expects #{'middleware/wrap-process-message}}
+^{:babashka.nrepl.server.middleware/requires #{'babashka.nrepl.server.middleware/wrap-read-msg}
+  :babashka.nrepl.server.middleware/expects #{'babashka.nrepl.server.middleware/wrap-process-message}}
  log-requests-middleware [handler]
   (fn [request]
     (swap! requests-log conj (:msg request))
     (handler request)))
 
 (defn
- ^{:babashka.nrepl.server.middleware/requires #{'middleware/wrap-response-for}}
+ ^{:babashka.nrepl.server.middleware/requires #{'babashka.nrepl.server.middleware/wrap-response-for}}
  log-responses-middleware [handler]
   (fn [response]
     (swap! responses-log conj (:response response))
@@ -718,15 +718,15 @@
               _ (sci/eval-string*
                  ctx
                  "(defn
-^{:babashka.nrepl.server.middleware/requires #{'middleware/wrap-read-msg}
-  :babashka.nrepl.server.middleware/expects #{'middleware/wrap-process-message}}
+^{:babashka.nrepl.server.middleware/requires #{'babashka.nrepl.server.middleware/wrap-read-msg}
+  :babashka.nrepl.server.middleware/expects #{'babashka.nrepl.server.middleware/wrap-process-message}}
  log-requests-middleware [handler]
   (fn [request]
     (swap! requests-log conj (:msg request))
     (handler request)))
 
 (defn
- ^{:babashka.nrepl.server.middleware/requires #{'middleware/wrap-response-for}}
+ ^{:babashka.nrepl.server.middleware/requires #{'babashka.nrepl.server.middleware/wrap-response-for}}
  log-responses-middleware [handler]
   (fn [response]
     (swap! responses-log conj (:response response))

--- a/test/babashka/nrepl/server_test.clj
+++ b/test/babashka/nrepl/server_test.clj
@@ -578,34 +578,34 @@
                 :response))))
 
     (testing "add extra ops via middleware"
-      (let [{:keys [ctx bindings opts]} (test-server-config)
-            responses (server-responses ctx bindings opts
-                                        (middleware/default-middleware-with-extra-ops
-                                         {:foo (fn [rf result request]
-                                                 (-> result
-                                                     (rf {:response {:foo-echo (-> request :msg :foo)}
-                                                          :response-for request})
-                                                     (rf {:response {:bar-echo (-> request :msg :bar)}
-                                                          :response-for request})))
-                                          :baz (fn [rf result request]
-                                                 (-> result
-                                                     (rf {:response {:baz-echo (-> request :msg :baz inc)}
-                                                          :response-for request})))})
-                                        [{"op" "foo"
-                                          "bar" "hasdf"
-                                          "foo" "yay"}
-                                         {"op" "baz"
-                                          "baz" 41}])]
-        (is (= '({:foo-echo "yay", "session" "none", "id" "unknown"}
-                 {:bar-echo "hasdf", "session" "none", "id" "unknown"}
-                 {:baz-echo 42, "session" "none", "id" "unknown"})
-               (map :response responses)))))
+     (let [{:keys [ctx bindings opts]} (test-server-config)
+           responses (server-responses ctx bindings opts
+                                       (middleware/default-middleware-with-extra-ops
+                                        {:foo (fn [rf result request]
+                                                (-> result
+                                                    (rf {:response {:foo-echo (-> request :msg :foo)}
+                                                         :response-for request})
+                                                    (rf {:response {:bar-echo (-> request :msg :bar)}
+                                                         :response-for request})))
+                                         :baz (fn [rf result request]
+                                                (-> result
+                                                    (rf {:response {:baz-echo (-> request :msg :baz inc)}
+                                                         :response-for request})))})
+                                       [{"op" "foo"
+                                         "bar" "hasdf"
+                                         "foo" "yay"}
+                                        {"op" "baz"
+                                         "baz" 41}])]
+       (is (= '({:foo-echo "yay", "session" "none", "id" "unknown"}
+                {:bar-echo "hasdf", "session" "none", "id" "unknown"}
+                {:baz-echo 42, "session" "none", "id" "unknown"})
+              (map :response responses)))))
 
     (testing "add logging middleware"
       (let [{:keys [ctx bindings opts]} (test-server-config)
             _ (reset! requests-log [])
             _ (reset! responses-log [])
-            _responses (server-responses ctx bindings opts
+            responses (server-responses ctx bindings opts
                                         (middleware/middleware->xform
                                          (conj middleware/default-middleware
                                                #'log-requests


### PR DESCRIPTION
https://github.com/babashka/babashka/issues/1529

- [ ] Need to handle somewhere that middleware args can also be a seq of middleware (for example cider.nrepl/cider-middleware). So something like flatten any lists of functions into a flat list of functions... ? 
Because --middleware right now is expected to be a sequence of symbols but a mix of symbols and lists of symbols should be allowed.